### PR TITLE
Use the nginx_refactoring branch of the modsecurity repository.

### DIFF
--- a/Repository/ulyaoth-nginx-modsecurity/build-ulyaoth-nginx-modsecurity.sh
+++ b/Repository/ulyaoth-nginx-modsecurity/build-ulyaoth-nginx-modsecurity.sh
@@ -31,10 +31,7 @@ cd /root
 rpmdev-setuptree
 mkdir -p /etc/nginx/modules
 cd /etc/nginx/modules
-wget https://www.modsecurity.org/tarball/2.9.0/modsecurity-2.9.0.tar.gz
-tar xvf modsecurity-2.9.0.tar.gz
-mv modsecurity-2.9.0 modsecurity
-rm -rf modsecurity-2.9.0.tar.gz
+git clone -b nginx_refactoring https://github.com/SpiderLabs/ModSecurity.git modsecurity
 cd modsecurity
 ./autogen.sh
 ./configure --enable-standalone-module


### PR DESCRIPTION
This branch contains numerous stability fixes for the modsecurity nginx port.